### PR TITLE
Filter undevelopable blocklots

### DIFF
--- a/mapblocklots_to_exclude.csv
+++ b/mapblocklots_to_exclude.csv
@@ -1,0 +1,47 @@
+APN,Description
+4175018,PGE Dogpatch Yard
+5023010,Candlestick Pt SRA
+4991703,Candlestick Pt SRA
+4991246,Candlestick Pt SRA
+4991001C,Candlestick Pt SRA
+6126016,Burton Prep School
+6071002,June Jordan High School
+3180002,Riordan High School
+4570025,USPS main sorting facility
+5262009,Municipal wastewater treatment plant
+5280001,Municipal wastewater treatment plant
+4154001,SF General Hospital
+4090002,SF General Hospital
+6573001,Mission Neighborhood Center / New city subsidized housing
+2842007,Laguna Honda Hospital
+2094006,St. Ignatius University
+7295035,SF State University
+7296004,SF State University
+7299005,SF State University
+7345001,Juan Batista Park
+7284001,Olympic club
+7380036,Lake Merced Golf Club
+1574001,George Washington High School
+1107008,University of San Francisco
+1145003,University of San Francisco
+1107009,University of San Francisco
+1107006,University of San Francisco
+1144001B,Koret Recreation Center
+1191041,St. Mary's Hospital
+1539003,Kaiser Permanente Hospital
+1072001,Muni Yard
+1105026,Wallenberg High School
+1077027,UCSF Mt. Zion
+1078072,UCSF Mt. Zion
+2634A005,UCSF Mt. Zion
+815001,SFUSD main office
+3759042,Jail / Courthouse
+8701004,Caltrain station
+3794028,Oracle Park
+3566055,"Mission Dolores, oldest structure in San Francisco"
+3539001,CPMC Davies Hospital
+409002,Fort Mason
+1095005,Kaiser Permanente Hospital
+1098050,Kaiser Permanente Hospital
+1592003,Balboa Natural Area
+1313021,The Cliff House

--- a/mapblocklots_to_exclude.csv
+++ b/mapblocklots_to_exclude.csv
@@ -45,3 +45,4 @@ APN,Description
 1098050,Kaiser Permanente Hospital
 1592003,Balboa Natural Area
 1313021,The Cliff House
+1313026,Sutro Baths


### PR DESCRIPTION
Added a branch in _filter_out_extraneous.r_ to exclude parcels which aren't likely to be developed (schools, hospitals, parks, government offices, etc). This could be provided by the user (ideally should be parameterized if we refactor main.r) but will be no-op if the file isn't present- so to disable this, just delete the file!