### PR TITLE
Consistent heights and naming with SF planning proposal

### DIFF
--- a/rezoner/app.R
+++ b/rezoner/app.R
@@ -12,9 +12,15 @@ source('./ui.R', local=T)
 source('./utils.R', local=T)
 model <- readRDS(file='./light_model.rds') 
 
-pal <- function(x, bins = c(1, 5, 8, 10, 20, Inf), palette = "viridis", right = FALSE) {
-  colors <- viridis::viridis(length(bins) - 1, option = palette)
-  colors <- stringr::str_sub(colors, 1, 7) # remove alpha channel
+# pal <- function(x, bins = c(1, 5, 8, 10, 20, Inf), palette = "viridis", right = FALSE) {
+#  colors <- viridis::viridis(length(bins) - 1, option = palette)
+#  colors <- stringr::str_sub(colors, 1, 7) # remove alpha channel
+#  binIndex <- findInterval(x, vec = bins, rightmost.closed = right, all.inside = TRUE)
+#  return(colors[binIndex])
+# }
+
+# pal <- function(x, bins = c(1, 5, 8, 10, 20, Inf), colors = c("#D2EBEB", "#F4AD3E", "#EC7520", "#E44520", "#AE2922", "#6C2F18"), right = FALSE) {
+pal <- function(x, bins = c(1, 6, 8, 14, 24, Inf), colors = c("#D2EBEB", "#F4AD3E", "#EC7520", "#E44520", "#AE2922", "#6C2F18"), right = FALSE) {
   binIndex <- findInterval(x, vec = bins, rightmost.closed = right, all.inside = TRUE)
   return(colors[binIndex])
 }
@@ -963,16 +969,20 @@ server <- function(input, output, session) {
   
   output$dynamicLegend <- renderUI({
     if (input$map == "heights") {
-      layers <- c('0-4 stories',
-                  '5-7 stories',
-                  '8-9 stories',
-                  '10-19 stories',
-                  '20+ stories')
-      colors <- c('#440154',
-                  '#3B528B',
-                  '#21908C',
-                  '#5DC863',
-                  '#FDE725')
+      layers <- c(#'unchanged',
+                  '65 feet (6 stories)',
+                  '85 feet(8 stories)',
+                  '140 feet (14 stories)',
+                  '240 feet (24 stories)',
+                  '300 feet (30 stories)'
+      )
+      colors <- c(#"#D2EBEB", 
+                  "#F4AD3E", 
+                  "#EC7520", 
+                  "#E44520", 
+                  "#AE2922", 
+                  "#6C2F18"
+                  )
       if (input$scenario %in% c('A', 'B', 'C', 'D', 'E')) {
         legend_name <- 'Zoning + Bonus'
       } else {

--- a/rezoner/app.R
+++ b/rezoner/app.R
@@ -12,14 +12,6 @@ source('./ui.R', local=T)
 source('./utils.R', local=T)
 model <- readRDS(file='./light_model.rds') 
 
-# pal <- function(x, bins = c(1, 5, 8, 10, 20, Inf), palette = "viridis", right = FALSE) {
-#  colors <- viridis::viridis(length(bins) - 1, option = palette)
-#  colors <- stringr::str_sub(colors, 1, 7) # remove alpha channel
-#  binIndex <- findInterval(x, vec = bins, rightmost.closed = right, all.inside = TRUE)
-#  return(colors[binIndex])
-# }
-
-# pal <- function(x, bins = c(1, 5, 8, 10, 20, Inf), colors = c("#D2EBEB", "#F4AD3E", "#EC7520", "#E44520", "#AE2922", "#6C2F18"), right = FALSE) {
 pal <- function(x, bins = c(1, 6, 8, 14, 24, Inf), colors = c("#D2EBEB", "#F4AD3E", "#EC7520", "#E44520", "#AE2922", "#6C2F18"), right = FALSE) {
   binIndex <- findInterval(x, vec = bins, rightmost.closed = right, all.inside = TRUE)
   return(colors[binIndex])


### PR DESCRIPTION
Addressing issue #3 and issue #4 : Coloring to be consistent with the SF Planning map (context: When presenting the rezoner app to my Neighborhood Association, people were immediately confused by the big splashes of unfamiliar color, and the difficulty of comparing the App with the SF Planning map.  The goal is to make it easy to have consistency between the two so that outside stakeholders can compare this easily with the SF Planning map (reach goal: have SF Planning staff *prefer* the Rezoner app over their map!)

Colors were picked directly from the SF planning map, and are exactly the SF color scheme- RGB values below
```
Height, RGB
6 stories:  244,173,62
8 stories:  236,117,32
14 stories: 228,69,32
24 stories: 174,41,34
30 stories: 108,47,24
4plex: 210,235,235
```

## Screenshots:

Current Planning PDF:
<img width="821" alt="pdf_current_planning_proposal" src="https://github.com/user-attachments/assets/c719cc57-f607-40a1-8301-328c88b2011f" />

Updated Rezoner app, same area:
![app_current_planning_proposal](https://github.com/user-attachments/assets/8ece79e1-b4c0-49a5-b3dc-959d8e07db9c)

Proposed YIMBY plan, full-city crop:
![yimby_proposal](https://github.com/user-attachments/assets/3e41ba45-6aa1-4c40-b85b-2f6864e3dbb5)

# TODO: 
- I changed the height bins from 1,5,8,10,20 to 1,6,8,14,24 to be consistent with SF Planning. Is this the right approach / how does this map to the back-end math for the regression?
- SF Planning's intent is for "total height" buckets (including State Density Bonus), whereas I believe the Yimby approach had been base height before SDB.  Is the back-end math comparable? 
- Are the height buckets consistent between all the scenarios?
- Is the "unchanged, but 4plexes allowed everywhere and 6plexes allowed on corners" zoning consistent with the "height = 1" bucket?  Why is the Sunset mostly untouched?